### PR TITLE
Add MVVM with SwiftUI as example

### DIFF
--- a/Arch.xcodeproj/project.pbxproj
+++ b/Arch.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		502654732725A0A1006BD3D8 /* MenuProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502654722725A0A1006BD3D8 /* MenuProtocols.swift */; };
 		502654752725A0A6006BD3D8 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502654742725A0A6006BD3D8 /* MenuView.swift */; };
 		502654782726EB19006BD3D8 /* MenuRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502654772726EB19006BD3D8 /* MenuRouter.swift */; };
+		502C519E2727A97F007B4818 /* SimpleMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502C519C2727A97F007B4818 /* SimpleMessageView.swift */; };
+		502C519F2727A97F007B4818 /* MessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502C519D2727A97F007B4818 /* MessageViewModel.swift */; };
 		50527976272708A600D96533 /* MessageRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50527975272708A600D96533 /* MessageRouter.swift */; };
 		50B428C21C385D9400939043 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B428C11C385D9400939043 /* AppDelegate.swift */; };
 		50B428C41C385D9400939043 /* MVCViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B428C31C385D9400939043 /* MVCViewController.swift */; };
@@ -51,6 +53,8 @@
 		502654722725A0A1006BD3D8 /* MenuProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuProtocols.swift; sourceTree = "<group>"; };
 		502654742725A0A6006BD3D8 /* MenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
 		502654772726EB19006BD3D8 /* MenuRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRouter.swift; sourceTree = "<group>"; };
+		502C519C2727A97F007B4818 /* SimpleMessageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleMessageView.swift; sourceTree = "<group>"; };
+		502C519D2727A97F007B4818 /* MessageViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageViewModel.swift; sourceTree = "<group>"; };
 		50527975272708A600D96533 /* MessageRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRouter.swift; sourceTree = "<group>"; };
 		50B428BE1C385D9400939043 /* Arch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Arch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		50B428C11C385D9400939043 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -191,6 +195,15 @@
 			path = router;
 			sourceTree = "<group>";
 		};
+		502C519B2727A97F007B4818 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				502C519C2727A97F007B4818 /* SimpleMessageView.swift */,
+				502C519D2727A97F007B4818 /* MessageViewModel.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
 		505279742727085A00D96533 /* router */ = {
 			isa = PBXGroup;
 			children = (
@@ -226,6 +239,7 @@
 				50C690D41C38F53B00806296 /* MVC */,
 				50C690D31C38F52100806296 /* MVP */,
 				50C690D61C38F85700806296 /* MVVM */,
+				502C519B2727A97F007B4818 /* SwiftUI */,
 				5026545327259FBE006BD3D8 /* VIPER */,
 				50B428C81C385D9400939043 /* Assets.xcassets */,
 				50B428CA1C385D9400939043 /* LaunchScreen.storyboard */,
@@ -380,6 +394,7 @@
 			files = (
 				50B428F21C38660800939043 /* MVPViewController.swift in Sources */,
 				5026546927259FBE006BD3D8 /* MessageInteractor.swift in Sources */,
+				502C519F2727A97F007B4818 /* MessageViewModel.swift in Sources */,
 				5026546F2725A096006BD3D8 /* MenuInteractor.swift in Sources */,
 				502654782726EB19006BD3D8 /* MenuRouter.swift in Sources */,
 				5026546627259FBE006BD3D8 /* MessagePresenter.swift in Sources */,
@@ -392,6 +407,7 @@
 				502654752725A0A6006BD3D8 /* MenuView.swift in Sources */,
 				50C690D21C38F36900806296 /* GreetingPresenter.swift in Sources */,
 				50B428F01C3860AE00939043 /* Person.swift in Sources */,
+				502C519E2727A97F007B4818 /* SimpleMessageView.swift in Sources */,
 				50B428C41C385D9400939043 /* MVCViewController.swift in Sources */,
 				50B428C21C385D9400939043 /* AppDelegate.swift in Sources */,
 				5026546727259FBE006BD3D8 /* MessageView.swift in Sources */,

--- a/Arch/SwiftUI/MessageViewModel.swift
+++ b/Arch/SwiftUI/MessageViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  MessageViewModel.swift
+//  Arch
+//
+//  Created by Miguel Angel Gómez Rivero on 25/10/21.
+//  Copyright © 2021 specktro. All rights reserved.
+//
+
+import Foundation
+
+// MARK: MessageViewModelProtocol protocol
+protocol MessageViewModelProtocol {
+  var greeting: String { get }
+  init(person: Person)
+  func showGreeting()
+}
+
+// MARK: MessageViewModel class
+final class MessageViewModel: ObservableObject, MessageViewModelProtocol {
+  // MARK: - Properties
+  @Published var greeting: String
+  var person: Person
+  
+  // MARK: - Initializer
+  init(person: Person) {
+    self.greeting = ""
+    self.person = person
+  }
+  
+  // MARK: - Methods
+  func showGreeting() {
+    self.greeting = "Hello" + " " + person.firstName + " " + person.lastName
+  }
+}

--- a/Arch/SwiftUI/SimpleMessageView.swift
+++ b/Arch/SwiftUI/SimpleMessageView.swift
@@ -1,0 +1,45 @@
+//
+//  MessageView.swift
+//  Arch
+//
+//  Created by Miguel Angel Gómez Rivero on 25/10/21.
+//  Copyright © 2021 specktro. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: SimpleMessageView struct
+struct SimpleMessageView: View {
+  // MARK: - Properties
+  @ObservedObject var viewModel: MessageViewModel
+  
+  // MARK: - Body
+  var body: some View {
+    ZStack {
+      Color.gray
+        .ignoresSafeArea()
+      
+      VStack {
+        Button {
+          viewModel.showGreeting()
+        } label: {
+          Label("TAP", systemImage: "hand.tap.fill")
+            .font(.system(size: 40, weight: .bold, design: .rounded))
+            .foregroundColor(.white)
+        }
+        Text(viewModel.greeting)
+          .font(.system(.body, design: .rounded))
+          .padding()
+      }
+    }
+  }
+}
+
+// MARK: - Preview
+struct MessageView_Previews: PreviewProvider {
+  static var previews: some View {
+    let person: Person = Person(firstName: "Sprieto", lastName: "Moreno")
+    let viewModel: MessageViewModel = MessageViewModel(person: person)
+    SimpleMessageView(viewModel: viewModel)
+  }
+}

--- a/Arch/VIPER/menu/interactor/MenuInteractor.swift
+++ b/Arch/VIPER/menu/interactor/MenuInteractor.swift
@@ -33,6 +33,8 @@ final class MenuInteractor: MenuInteractorProtocol {
       presenter?.goToMVVM()
     case "VIPER":
       presenter?.goToVIPER()
+    case "MVVM + SwiftUI":
+      presenter?.goToSwiftUI()
     default:
       presenter?.goToError()
     }

--- a/Arch/VIPER/menu/presenter/MenuPresenter.swift
+++ b/Arch/VIPER/menu/presenter/MenuPresenter.swift
@@ -44,6 +44,10 @@ final class MenuPresenter: MenuPresenterProtocol {
     router.showVIPER(from: view)
   }
   
+  func goToSwiftUI() {
+    router.showSwiftUI(from: view)
+  }
+  
   func goToError() {
     router.showError(from: view)
   }

--- a/Arch/VIPER/menu/protocols/MenuProtocols.swift
+++ b/Arch/VIPER/menu/protocols/MenuProtocols.swift
@@ -29,6 +29,7 @@ protocol MenuPresenterProtocol: AnyObject {
   func goToMVP()
   func goToMVVM()
   func goToVIPER()
+  func goToSwiftUI()
   func goToError()
 }
 
@@ -50,5 +51,6 @@ protocol MenuRouterProtocol {
   func showMVP(from view: MenuViewProtocol?)
   func showMVVM(from view: MenuViewProtocol?)
   func showVIPER(from view: MenuViewProtocol?)
+  func showSwiftUI(from view: MenuViewProtocol?)
   func showError(from view: MenuViewProtocol?)
 }

--- a/Arch/VIPER/menu/router/MenuRouter.swift
+++ b/Arch/VIPER/menu/router/MenuRouter.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 // MARK: MenuRouter class
 final class MenuRouter: MenuRouterProtocol {
@@ -14,7 +15,7 @@ final class MenuRouter: MenuRouterProtocol {
   func createModule() -> MenuViewProtocol {
     let view: MenuViewProtocol = MenuView()
     let presenter: MenuPresenterProtocol = MenuPresenter()
-    let interactor: MenuInteractorProtocol = MenuInteractor(options: ["MVC", "MVP", "MVVM", "VIPER"])
+    let interactor: MenuInteractorProtocol = MenuInteractor(options: ["MVC", "MVP", "MVVM", "VIPER", "MVVM + SwiftUI"])
     view.presenter = presenter
     presenter.view = view
     presenter.interactor = interactor
@@ -52,6 +53,17 @@ final class MenuRouter: MenuRouterProtocol {
   func showVIPER(from view: MenuViewProtocol? = nil) {
     let messageRouter: MessageRouterProtocol = MessageRouter()
     let newView: MessageViewProtocol = messageRouter.createModule()
+    
+    view?.navigationController?.pushViewController(newView, animated: true)
+  }
+  
+  func showSwiftUI(from view: MenuViewProtocol?) {
+    let model: Person = Person(firstName: "Sprieto", lastName: "Moreno")
+    let messageViewModel: MessageViewModel = MessageViewModel(person: model)
+    let messageView: SimpleMessageView = SimpleMessageView(viewModel: messageViewModel)
+    let newView: UIHostingController = UIHostingController(rootView: messageView)
+    newView.title = "MVVM + SwiftUI"
+    newView.navigationItem.largeTitleDisplayMode = .never
     
     view?.navigationController?.pushViewController(newView, animated: true)
   }


### PR DESCRIPTION
## Summary
Add new **MVVM** pattern but now with `SwiftUI`, it is different from **MVVM** with `UIKit` but now we are using `Combine` with `ObservableObject` and `@Published`
```Swift
// MARK: MessageViewModelProtocol protocol
protocol MessageViewModelProtocol {
  var greeting: String { get }
  init(person: Person)
  func showGreeting()
}

// MARK: MessageViewModel class
final class MessageViewModel: ObservableObject, MessageViewModelProtocol {
  // MARK: - Properties
  @Published var greeting: String
  var person: Person
  
  // MARK: - Initializer
  init(person: Person) {
    self.greeting = ""
    self.person = person
  }
  
  // MARK: - Methods
  func showGreeting() {
    self.greeting = "Hello" + " " + person.firstName + " " + person.lastName
  }
}
```
and the view is simple:
```Swift
// MARK: SimpleMessageView struct
struct SimpleMessageView: View {
  // MARK: - Properties
  @ObservedObject var viewModel: MessageViewModel
  
  // MARK: - Body
  var body: some View {
    VStack {
      Button {
        // Trigger action
        viewModel.showGreeting()
      } label: { ... }
      // Show message
      Text(viewModel.greeting)
        .font(.system(.body, design: .rounded))
        .padding()
    }
  }
}
```
We are combining `UIKit` and `SwiftUI` so we have to embed the view into `UIHostingViewController` and it is very simple:
```Swift
let view: SwiftUIView = SwiftUIView()
let hostingViewController: UIHostingController = UIHostingController(rootView: view)
```